### PR TITLE
Changed import order

### DIFF
--- a/ecs.php
+++ b/ecs.php
@@ -20,9 +20,9 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(OrderedImportsFixer::class)->call('configure', [
         [
             'importsOrder' => [
-                OrderedImportsFixer::IMPORT_TYPE_CONST,
                 OrderedImportsFixer::IMPORT_TYPE_CLASS,
-                OrderedImportsFixer::IMPORT_TYPE_FUNCTION
+                OrderedImportsFixer::IMPORT_TYPE_FUNCTION,
+                OrderedImportsFixer::IMPORT_TYPE_CONST
             ]
         ]
     ]);


### PR DESCRIPTION
`CONST` in `PHPStrom` was setup in the bottom of import. We can't change it in PHP Strom, so we need to adjust