### PR TITLE
Update dependencies (starting with PHPStan update):

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,19 +4,19 @@
     "license": "MIT",
     "require": {
         "php": ">=7.4",
-        "phpstan/phpstan": "1.4.2",
-        "phpstan/phpstan-doctrine": "1.1.0",
-        "phpstan/phpstan-phpunit": "1.0.0",
-        "phpstan/phpstan-symfony": "1.1.2",
+        "phpstan/phpstan": "~1.9.2",
+        "phpstan/phpstan-doctrine": "~1.3.23",
+        "phpstan/phpstan-phpunit": "~1.2.2",
+        "phpstan/phpstan-symfony": "~1.2.16",
         "phpstan/extension-installer": "^1.1",
-        "symplify/easy-coding-standard": "9.4.22",
-        "symfony/polyfill-php80": "^1.23",
-        "povils/phpmnd": "^2.4"
+        "symplify/easy-coding-standard": "~11.1.17",
+        "symfony/polyfill-php80": "^1.27",
+        "povils/phpmnd": "~3.0.1"
     },
     "require-dev": {
         "roave/security-advisories": "dev-latest",
-        "symfony/dotenv": "^5.3",
-        "phpunit/phpunit": "^9.5"
+        "symfony/dotenv": "~5.4.5",
+        "phpunit/phpunit": "~9.5.26"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
- phpstan/phpstan: `1.4.2` -> `~1.9.2`
- phpstan/phpstan-doctrine: `1.1.0` -> `~1.3.23`
- phpstan/phpstan-phpunit: `1.0.0` -> `~1.2.2`
- phpstan/phpstan-symfony: `1.1.2` -> `~1.2.16`
- **symplify/easy-coding-standard**: `9.4.22` -> `~11.1.17`
- symfony/polyfill-php80: `^1.23` -> `^1.27`
- **povils/phpmnd**: `^2.4` -> `~3.0.1`

Dev dependencies were just made more specific to what is actually installed, without changing the version