### PR TITLE
Update dependencies (starting with PHPStan update):

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 ci:
 	composer validate
-	vendor/bin/ecs check --debug --config ecs.php
+	vendor/bin/ecs check --debug src
 	vendor/bin/ecs list --ansi --debug
 	vendor/bin/phpunit

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 ci:
 	composer validate
-	vendor/bin/ecs show --debug --config ecs.php
+	vendor/bin/ecs check --debug --config ecs.php
 	vendor/bin/ecs list --ansi --debug
 	vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -27,5 +27,10 @@
         "psr-4": {
             "Landingi\\": "tests/"
         }
+    },
+    "config": {
+        "allow-plugins": {
+            "phpstan/extension-installer": true
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -4,19 +4,19 @@
     "license": "MIT",
     "require": {
         "php": ">=7.4",
-        "phpstan/phpstan": "1.4.2",
-        "phpstan/phpstan-doctrine": "1.1.0",
-        "phpstan/phpstan-phpunit": "1.0.0",
-        "phpstan/phpstan-symfony": "1.1.2",
+        "phpstan/phpstan": "~1.9.2",
+        "phpstan/phpstan-doctrine": "~1.3.23",
+        "phpstan/phpstan-phpunit": "~1.2.2",
+        "phpstan/phpstan-symfony": "~1.2.16",
         "phpstan/extension-installer": "^1.1",
-        "symplify/easy-coding-standard": "9.4.22",
-        "symfony/polyfill-php80": "^1.23",
-        "povils/phpmnd": "^2.4"
+        "symplify/easy-coding-standard": "~11.1.17",
+        "symfony/polyfill-php80": "^1.27",
+        "povils/phpmnd": "~3.0.1"
     },
     "require-dev": {
         "roave/security-advisories": "dev-latest",
-        "symfony/dotenv": "^5.3",
-        "phpunit/phpunit": "^9.5"
+        "symfony/dotenv": "~5.4.5",
+        "phpunit/phpunit": "~9.5.26"
     },
     "autoload": {
         "psr-4": {

--- a/ecs.php
+++ b/ecs.php
@@ -1,18 +1,16 @@
 <?php
 declare(strict_types=1);
 
-use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
-use Symplify\EasyCodingStandard\ValueObject\Option;
+use Symplify\EasyCodingStandard\Config\ECSConfig;
 use Landingi\ClassNameSuffixFixer;
 use Landingi\InterfaceNameSuffixFixer;
 
-return static function (ContainerConfigurator $containerConfigurator): void {
-    $parameters = $containerConfigurator->parameters();
-    $parameters->set(Option::PATHS, [
+return static function (ECSConfig $ecsConfig): void {
+    $ecsConfig->paths([
         \dirname(__DIR__) . '/../../src',
         \dirname(__DIR__) . '/../../tests'
     ]);
-    $services = $containerConfigurator->services();
+    $services = $ecsConfig->services();
 
     //ControlStructure
     $services->set(\PhpCsFixer\Fixer\ControlStructure\NoUnneededControlParenthesesFixer::class);

--- a/src/ClassNameSuffixFixer.php
+++ b/src/ClassNameSuffixFixer.php
@@ -55,7 +55,7 @@ PHP;
         return new FixerDefinition(
             'Removes Service and Entity class suffix',
             [
-                new CodeSample($codeSample)
+                new CodeSample($codeSample),
             ]
         );
     }

--- a/src/InterfaceNameSuffixFixer.php
+++ b/src/InterfaceNameSuffixFixer.php
@@ -31,14 +31,13 @@ class InterfaceNameSuffixFixer implements FixerInterface
             if ($token->isGivenKind(T_INTERFACE)) {
                 $interfaceName = $tokens[$index + 2]->getContent();
 
-                if (str_ends_with($interfaceName, 'Interface') && $interfaceName !== 'CreatorInterface') {
+                if (str_ends_with($interfaceName, 'Interface') && 'CreatorInterface' !== $interfaceName) {
                     $newToken = str_replace('Interface', '', $interfaceName);
                     $tokens[$index + 2] = new Token([$index + 2, $newToken]);
                 }
             }
         }
     }
-
 
     public function getDefinition(): FixerDefinitionInterface
     {
@@ -53,7 +52,7 @@ PHP;
         return new FixerDefinition(
             'Removes interface suffix from interfaces',
             [
-                new CodeSample($codeSample)
+                new CodeSample($codeSample),
             ]
         );
     }

--- a/tests/ClassNameSuffixFixerTest.php
+++ b/tests/ClassNameSuffixFixerTest.php
@@ -30,25 +30,25 @@ class ClassNameSuffixFixerTest extends TestCase
     }
 
     /**
-     * yields [Code to Fix, Expected Result]
+     * yields [Code to Fix, Expected Result].
      */
     public function data(): Generator
     {
         yield [
             file_get_contents('tests/class_name_suffix_fixer/test_1_input.php'),
-            file_get_contents('tests/class_name_suffix_fixer/test_1_output.php')
+            file_get_contents('tests/class_name_suffix_fixer/test_1_output.php'),
         ];
         yield [
             file_get_contents('tests/class_name_suffix_fixer/test_2_input.php'),
-            file_get_contents('tests/class_name_suffix_fixer/test_2_output.php')
+            file_get_contents('tests/class_name_suffix_fixer/test_2_output.php'),
         ];
         yield [
             file_get_contents('tests/class_name_suffix_fixer/test_3_input.php'),
-            file_get_contents('tests/class_name_suffix_fixer/test_3_output.php')
+            file_get_contents('tests/class_name_suffix_fixer/test_3_output.php'),
         ];
         yield [
             file_get_contents('tests/class_name_suffix_fixer/test_4_input.php'),
-            file_get_contents('tests/class_name_suffix_fixer/test_4_output.php')
+            file_get_contents('tests/class_name_suffix_fixer/test_4_output.php'),
         ];
     }
 }

--- a/tests/InterfaceNameSuffixFixerTest.php
+++ b/tests/InterfaceNameSuffixFixerTest.php
@@ -30,7 +30,7 @@ class InterfaceNameSuffixFixerTest extends TestCase
     }
 
     /**
-     * yields [Code to Fix, Expected Result]
+     * yields [Code to Fix, Expected Result].
      */
     public function data(): Generator
     {


### PR DESCRIPTION
The (potential) breaking changes are highlighted in bold:

- phpstan/phpstan: `1.4.2` -> `~1.9.2`
- phpstan/phpstan-doctrine: `1.1.0` -> `~1.3.23`
- phpstan/phpstan-phpunit: `1.0.0` -> `~1.2.2`
- phpstan/phpstan-symfony: `1.1.2` -> `~1.2.16`
- **symplify/easy-coding-standard**: `9.4.22` -> `~11.1.17`
- symfony/polyfill-php80: `^1.23` -> `^1.27`
- **povils/phpmnd**: `^2.4` -> `~3.0.1`

Dev dependencies were just made more specific to what is actually installed, without changing the version